### PR TITLE
Fix building on linux

### DIFF
--- a/XtractQuery/Logic.Domain.Kuriimu2.KomponentAdapter/Logic.Domain.Kuriimu2.KomponentAdapter/Logic.Domain.Kuriimu2.KomponentAdapter.csproj
+++ b/XtractQuery/Logic.Domain.Kuriimu2.KomponentAdapter/Logic.Domain.Kuriimu2.KomponentAdapter/Logic.Domain.Kuriimu2.KomponentAdapter.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\CrossCutting.Core.Contract\CrossCutting.Core.Contract.csproj" />
-    <ProjectReference Include="..\Logic.domain.Kuriimu2.KomponentAdapter.Contract\Logic.Domain.Kuriimu2.KomponentAdapter.Contract.csproj" />
+    <ProjectReference Include="..\Logic.Domain.Kuriimu2.KomponentAdapter.Contract\Logic.Domain.Kuriimu2.KomponentAdapter.Contract.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Incredibly small fix - because of a one letter typo ('d' instead of 'D'), XtractQuery fails to build on operating systems with case-sensitive filesystems like linux.